### PR TITLE
fix permissions using UID/GID given ny env

### DIFF
--- a/rootfs/etc/cont-init.d/02-fix-perms.sh
+++ b/rootfs/etc/cont-init.d/02-fix-perms.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/with-contenv sh
-
 echo "Fixing perms..."
-mkdir -p /data/db \
-  /data/journal \
-  /var/run/rrdcached
-chown rrdcached. \
-  /data/db \
-  /data/journal
-chown -R rrdcached. \
-  /var/run/rrdcached
+mkdir -p /data/db /data/journal /var/run/rrdcached
+chown ${PUID:-1000}:${PGID:-1000} /data/db /data/journal
+chown -R ${PUID:-1000}:${PGID:-1000} /var/run/rrdcached


### PR DESCRIPTION
the current syntax for chown is wrong as mentioned in issue #64 

further, it should use the UID/GID from the environment variables instead of the hardcoded username